### PR TITLE
fix(cd): make prominence permissions global

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -8,13 +8,14 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish-jsr:
     name: publish / jsr
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
       - run: npm ci


### PR DESCRIPTION
This fixes NPM deployment not having the same permissions as jsr. It can go up in the next release, no rush.